### PR TITLE
Added php_pecl_package attribute and set default to final PHP5 versio…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,6 @@ default[:oracle_instantclient][:client_version] = "11.2.0.3.0"
 default[:oracle_instantclient][:client_dir_name] = "instantclient_11_2"
 default[:oracle_instantclient][:download_base] = "http://exodus.socsci.umn.edu/redhat/oracle-instantclient"
 default[:oracle_instantclient][:install_dir] = "/usr/local"
+
+# oci8-2.0.10 is the final version for PHP5
+default[:oracle_instantclient][:php_pecl_package] = "oci8-2.0.10"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "buysse@umn.edu"
 license          "Apache 2.0"
 description      "Installs/Configures oracle-instantclient"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.3.2"
+version          "0.3.3"
 
 supports "ubuntu"

--- a/templates/default/install_pecl_oci8.exp.erb
+++ b/templates/default/install_pecl_oci8.exp.erb
@@ -1,7 +1,7 @@
 set timeout 300
 spawn pecl update-channels
 expect eof
-spawn pecl install oci8
+spawn pecl install <%= node[:oracle_instantclient][:php_pecl_package] %>
 expect " compiling with Oracle Instant Client"
 send -- "instantclient,<%= "#{node[:oracle_instantclient][:install_dir]}/#{node[:oracle_instantclient][:client_dir_name]}" %>\r"
 expect "install ok:"


### PR DESCRIPTION
Sets the php pecl package version to the final PHP5 version (oci8-2.0.10). The latest version is only for PHP7 and won't install on PHP5.